### PR TITLE
Add missing `typing` import to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import typing as tp
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 import site, os


### PR DESCRIPTION
This was removed in d059d49d84d5f9adc0cd6924115454eb342f948a, but is still used in [`get_ext_dir`](https://github.com/static-frame/arraykit/blob/6696d9a5ad2c42084a7ae0711b0a0d71214c446a/setup.py#L8). (Tbh I'm not sure why builds have still been working, but when I tried to build from source today it error'ed on the unknown `tp`.)